### PR TITLE
Rework OMERTA.STI (map of Arulco).

### DIFF
--- a/editor/README.md
+++ b/editor/README.md
@@ -82,7 +82,7 @@ The following list was created from the list of image sizes provided by @selaux 
 | NUM3.STI             | 30x30          | not used, has 6 images: 0+1+2+3+4=30x30 (button?) and 5=3x2 |
 | NUM4.STI             | 30x30          | not used, has 6 images: 0+1+2+3+4=30x30 (button?) and 5=3x2 |
 | OK.STI               | 30x30          | full button, ok, has 1 extra image: 5=398x130 |
-| OMERTA.STI           | 212x212        | image, omerta map? |
+| OMERTA.STI           | 212x212        | image, map of Arulco (16x16 grid, 2 pixel border) |
 | PAINT.STI            | 30x30          | button, "Cycle brush size" |
 | RADIOBUTTON.STI      | 12x12          | radio button |
 | RIGHTARROW.STI       | 30x20          | button, right arrow |

--- a/editor/images.py
+++ b/editor/images.py
@@ -139,16 +139,77 @@ def add_LGDOWNARROW_LGUPARROW_STI(source_fs, target_fs):
 
 
 def add_OMERTA_STI(source_fs, target_fs):
+    """map of Arulco (16x16 grid, 2 pixel border)"""
     text = "OMERTA"
-    font = ImageFont.truetype(source_fs.getsyspath("silkscreen/slkscr.ttf"), 32)
-    color = ImageColor.getrgb('#403C22')
-    backgound = ImageColor.getrgb('#E6D77C')
-    image = Image.new('RGB', (212, 212), backgound)
+    water_color = ImageColor.getrgb('#4A5FFF')
+    shore_color = ImageColor.getrgb('#CCAD76')
+    land_color = ImageColor.getrgb('#428021')
+    pen_color = ImageColor.getrgb('#080808')
+    town_color = ImageColor.getrgb('#BF7737')
+    font = ImageFont.truetype(source_fs.getsyspath("silkscreen/slkscr.ttf"), 8)
+    image = Image.new('RGB', (212, 212), water_color)
     draw = ImageDraw.Draw(image)
-    text_width, text_height = draw.textsize(text, font=font, spacing=-1)
-    x = (212 - text_width) // 2
-    y = (212 - text_height) // 2
-    draw.text((x,y), text, fill=color, font=font, spacing=-1, align='center')
+    def pixel(coord):
+        return 2 + int(round(208 * coord / 16))
+    def pixels(x, y, off):
+        arr = []
+        arr.append(pixel(x))
+        arr.append(pixel(y))
+        for i in range(len(off)):
+            if i % 2 == 0:
+                x += off[i]
+                arr.append(pixel(x))
+            else:
+                y += off[i]
+                arr.append(pixel(y))
+        return arr
+    shoreline = pixels(1.5,-.5, [
+        -1,1, 0,2, 1,1, 0,2, -1,1,
+        0,1, 1,0, 1,1, -1,1, 0,1,
+        -1,1, 2,2, 0,2, 2,-2, 2,0,
+        1,1, 1,0, 1,-1, 0,-1, 1,-1,
+        1,0, 1,1, 0,1, 1,1, 0,1,
+        1,1, 2,0, 0,-17])
+    draw.polygon(shoreline, land_color, shore_color)
+    def paste_texts(arr):
+        for i in range(0, len(arr), 3):
+            x0 = pixel(arr[i])
+            y0 = pixel(arr[i + 1])
+            x1 = pixel(arr[i] + 1) + 1
+            y1 = pixel(arr[i + 1] + 1) - 1
+            text = arr[i + 2]
+            text_image = make_glow_text_image(x1-x0, y1-y0, text, font, pen_color, shore_color)
+            image.paste(text_image, (x0,y0,x1,y1), text_image)
+    # town grid cells
+    draw.polygon(pixels(1, 0, [1,0, 0,2, -1,0]), town_color, None) # chitzena
+    draw.polygon(pixels(8, 0, [2,0, 0,1, -2,0]), town_color, None) # omerta
+    draw.polygon(pixels(12, 1, [1,0, 0,3, -1,0]), town_color, None) # drassen
+    draw.polygon(pixels(4, 2, [2,0, 0,1, -1,0, 0,1, -2,0, 0,-1, 1,0]), town_color, None) # san mona
+    draw.polygon(pixels(7, 5, [2,0, 0,2, -1,0, 0,1, -1,0]), town_color, None) # cambria
+    draw.polygon(pixels(0, 6, [2,0, 0,1, 1,0, 0,1, -3,0]), town_color, None) # grumm
+    draw.polygon(pixels(12, 7, [2,0, 0,2, -2,0]), town_color, None) # alma
+    draw.polygon(pixels(10, 11, [2,0, 0,1, -2,0]), town_color, None) # balime
+    draw.polygon(pixels(2, 13, [3,0, 0,1, -1,0, 0,1, -1,0, 0,1, -1,0]), town_color, None) # meduna
+    # roads
+    draw.line(pixels(1.5, 2, [0,0.5, 1,0, 0,7, -1,0, 0,3, 1,0, 0,0.5]), pen_color, 3)
+    draw.line(pixels(4.5, 13, [0,-0.5, 1,0, 0,-6, 1,0, 0,-3, -1,0, 0,-1, 3,0, 0,-2]), pen_color, 3)
+    draw.line(pixels(2, 7.5, [0.5,0, 0,-1, 6,0, 0,-5, 4,0, 0,3, -1,0, 0,3, 2,0, 0,3, -8,0]), pen_color, 3)
+    draw.line(pixels(5, 13.5, [4.5,0, 0,-3, 1,0, 0,1, 0.5,0]), pen_color, 3)
+    draw.line(pixels(8.5, 6.5, [3,0, 0,1, 1,0, 0,1, 1,0]), pen_color, 3)
+    # labels
+    T = "" # town
+    M = "M" # town with mine
+    A = "A" # town with airport
+    P = "P" #  town with palace
+    paste_texts([1,0,T, 1,1,M]) # chitzena
+    paste_texts([8,0,T, 9,0,T]) # omerta
+    paste_texts([12,1,A, 12,2,T, 12,3,M]) # drassen
+    paste_texts([4,2,T, 5,2,T, 3,3,M, 4,3,T]) # san mona
+    paste_texts([7,5,T, 8,5,T, 7,6,T, 8,6,T, 7,7,M]) # cambria
+    paste_texts([0,6,T, 1,6,T, 0,7,T, 1,7,T, 2,7,M]) # grumm
+    paste_texts([12,7,T, 13,7,T, 12,8,T, 13,8,M]) # alma
+    paste_texts([10,11,T, 11,11,T]) # balime
+    paste_texts([2,13,A, 3,13,T, 4,13,T, 2,14,T, 3,14,T, 2,15,P]) # meduna
     buf = BytesIO()
     image.save(buf, format='STCI', flags=['INDEXED', 'ETRLE'])
     with target_fs.open("OMERTA.STI", 'wb') as f:
@@ -165,4 +226,5 @@ def add_to_free_editorslf(source_fs, target_fs):
     add_KEYIMAGE_STI(source_fs, target_fs)
     add_LGDOWNARROW_LGUPARROW_STI(source_fs, target_fs)
     add_OMERTA_STI(source_fs, target_fs)
+
 


### PR DESCRIPTION
Tried exploring the editor and found that `OMERTA.STI` is supposed to be the map of Arulco.
Made a basic replacement that looks like this (generated):
![OMERTA STI](https://user-images.githubusercontent.com/1009600/62500914-606fae80-b7e0-11e9-9cfc-2a0268838761.png)